### PR TITLE
Adds ability to abort requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This package provides an easy way to use the [Langflow API](https://docs.datasta
   - [Calling a flow](#calling-a-flow)
     - [Flow reponses](#flow-reponses)
   - [File upload](#file-upload)
+  - [Aborting requests](#aborting-requests)
 - [Contributing](#contributing)
 
 ## Installation
@@ -157,6 +158,21 @@ const response = await flow.tweak("ChatInput-abcd": { files: file.filePath }).ru
 
 > [!WARNING]  
 > DataStax Langflow doesn't make file upload available, you will receive a 501 Not Implemented error.
+
+### Aborting requests
+
+You can use the standard [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) to cancel requests by passing a `signal` to the `run` or `uploadFile` functions. The functions will reject with a `DOMException` error with the name `AbortError` or, if you use [`AbortSignal.timeout`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static), `TimeoutError`.
+
+For example, when running the following code, if the entire request takes longer than 500ms, then the promise will reject and the error message will be, "The operation was aborted due to timeout".
+
+```js
+const signal = AbortSignal.timeout(500);
+try {
+  const response = await client.flow(flowId).run(input, { signal });
+} catch (error) {
+  console.error(error.message);
+}
+```
 
 ## Contributing
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -39,3 +39,5 @@ export class LangflowRequestError extends Error {
     return this.cause;
   }
 }
+
+export class LangflowAbortError extends Error {}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -39,5 +39,3 @@ export class LangflowRequestError extends Error {
     return this.cause;
   }
 }
-
-export class LangflowAbortError extends Error {}

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -28,7 +28,6 @@ import {
 
 import { readFile } from "node:fs/promises";
 import { extname, basename } from "node:path";
-import { sign } from "node:crypto";
 
 export class Flow {
   client: LangflowClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,7 @@
 import { fetch, FormData } from "undici";
 
 import pkg from "../package.json" with { type: "json" };
-import {
-  LangflowError,
-  LangflowRequestError,
-  LangflowAbortError,
-} from "./errors.js";
+import { LangflowError, LangflowRequestError } from "./errors.js";
 import { Flow } from "./flow.js";
 import type { LangflowClientOptions, Tweaks } from "./types.js";
 import { DATASTAX_LANGFLOW_BASE_URL } from "./consts.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,13 +79,15 @@ export class LangflowClient {
     return new Flow(this, flowId, tweaks);
   }
 
-  async request(
-    path: string,
-    method: string,
-    body: string | FormData,
-    headers: Headers,
-    query?: Record<string, string>
-  ): Promise<unknown> {
+  async request(options: {
+    path: string;
+    method: string;
+    body: string | FormData;
+    headers: Headers;
+    query?: Record<string, string>;
+    signal?: AbortSignal;
+  }): Promise<unknown> {
+    const { path, method, body, headers, query, signal } = options;
     const url = new URL(`${this.baseUrl}${this.basePath}${path}`);
     for (const [header, value] of this.defaultHeaders.entries()) {
       if (!headers.has(header)) {
@@ -101,7 +103,7 @@ export class LangflowClient {
       this.#setApiKey(this.apiKey, headers);
     }
     try {
-      const response = await this.fetch(url, { method, body, headers });
+      const response = await this.fetch(url, { method, body, headers, signal });
       if (!response.ok) {
         throw new LangflowError(
           `${response.status} - ${response.statusText}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,11 +118,13 @@ export class LangflowClient {
       signal?.throwIfAborted();
       return await response.json();
     } catch (error) {
-      if (error instanceof LangflowError) {
+      // If it is a LangflowError or the result of an aborted signal, rethrow it
+      if (
+        error instanceof LangflowError ||
+        (error instanceof DOMException &&
+          (error.name === "AbortError" || error.name === "TimeoutError"))
+      ) {
         throw error;
-      }
-      if (error instanceof DOMException && error.name === "AbortError") {
-        throw new LangflowAbortError(error.message, { cause: error });
       }
       if (error instanceof Error) {
         throw new LangflowRequestError(error.message, error);

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -15,11 +15,7 @@
 import { Headers } from "undici";
 
 import { LangflowClient } from "../index.js";
-import {
-  LangflowRequestError,
-  LangflowError,
-  LangflowAbortError,
-} from "../errors.js";
+import { LangflowRequestError, LangflowError } from "../errors.js";
 import { Flow } from "../flow.js";
 import { DATASTAX_LANGFLOW_BASE_URL } from "../consts.js";
 import { createMockFetch } from "./utils.js";
@@ -235,7 +231,7 @@ describe("LangflowClient", () => {
         }
       });
 
-      it("throws a LangflowAbortError if the request is aborted", async () => {
+      it("throws a DOMException AbortError if the request is aborted", async () => {
         const fetcher = createMockFetch(
           { session_id: "session-id", outputs: [] },
           () => {
@@ -265,7 +261,7 @@ describe("LangflowClient", () => {
           });
           assert.fail("Expected an error to be thrown");
         } catch (error) {
-          assert.ok(error instanceof LangflowAbortError);
+          assert.ok(error instanceof DOMException);
           assert.equal(error.message, ac.signal.reason.message);
         }
       });

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -94,16 +94,16 @@ describe("LangflowClient", () => {
           apiKey,
           fetch: fetcher,
         });
-        const response = await client.request(
-          "/run/flow-id",
-          "POST",
-          JSON.stringify({
+        const response = await client.request({
+          path: "/run/flow-id",
+          method: "POST",
+          body: JSON.stringify({
             input_type: "chat",
             output_type: "chat",
             input_value: "Hello, world!",
           }),
-          new Headers()
-        );
+          headers: new Headers(),
+        });
         assert.deepEqual(response, { session_id: "session-id", outputs: [] });
       });
 
@@ -122,16 +122,16 @@ describe("LangflowClient", () => {
           apiKey,
           fetch: fetcher,
         });
-        await client.request(
-          "/run/flow-id",
-          "POST",
-          JSON.stringify({
+        await client.request({
+          path: "/run/flow-id",
+          method: "POST",
+          body: JSON.stringify({
             input_type: "chat",
             output_type: "chat",
             input_value: "Hello, world!",
           }),
-          new Headers()
-        );
+          headers: new Headers(),
+        });
       });
 
       it("includes a user agent in the headers", async () => {
@@ -154,16 +154,16 @@ describe("LangflowClient", () => {
           apiKey,
           fetch: fetcher,
         });
-        await client.request(
-          "/run/flow-id",
-          "POST",
-          JSON.stringify({
+        await client.request({
+          path: "/run/flow-id",
+          method: "POST",
+          body: JSON.stringify({
             input_type: "chat",
             output_type: "chat",
             input_value: "Hello, world!",
           }),
-          new Headers()
-        );
+          headers: new Headers(),
+        });
       });
 
       it("throws a LangflowError if the response is not ok", async () => {
@@ -182,16 +182,16 @@ describe("LangflowClient", () => {
         });
 
         try {
-          await client.request(
-            "/run/flow-id",
-            "POST",
-            JSON.stringify({
+          await client.request({
+            path: "/run/flow-id",
+            method: "POST",
+            body: JSON.stringify({
               input_type: "chat",
               output_type: "chat",
               input_value: "Hello, world!",
             }),
-            new Headers()
-          );
+            headers: new Headers(),
+          });
           assert.fail("Expected an error to be thrown");
         } catch (error) {
           assert.ok(error instanceof LangflowError);
@@ -214,16 +214,16 @@ describe("LangflowClient", () => {
         });
 
         try {
-          await client.request(
-            "/run/flow-id",
-            "POST",
-            JSON.stringify({
+          await client.request({
+            path: "/run/flow-id",
+            method: "POST",
+            body: JSON.stringify({
               input_type: "chat",
               output_type: "chat",
               input_value: "Hello, world!",
             }),
-            new Headers()
-          );
+            headers: new Headers(),
+          });
           assert.fail("Expected an error to be thrown");
         } catch (error) {
           assert.ok(error instanceof LangflowRequestError);
@@ -268,16 +268,16 @@ describe("LangflowClient", () => {
           baseUrl,
           fetch: fetcher,
         });
-        const response = await client.request(
-          "/run/flow-id",
-          "POST",
-          JSON.stringify({
+        const response = await client.request({
+          path: "/run/flow-id",
+          method: "POST",
+          body: JSON.stringify({
             input_type: "chat",
             output_type: "chat",
             input_value: "Hello, world!",
           }),
-          new Headers()
-        );
+          headers: new Headers(),
+        });
         assert.deepEqual(response, { session_id: "session-id", outputs: [] });
       });
 
@@ -295,16 +295,16 @@ describe("LangflowClient", () => {
           apiKey,
           fetch: fetcher,
         });
-        await client.request(
-          "/run/flow-id",
-          "POST",
-          JSON.stringify({
+        await client.request({
+          path: "/run/flow-id",
+          method: "POST",
+          body: JSON.stringify({
             input_type: "chat",
             output_type: "chat",
             input_value: "Hello, world!",
           }),
-          new Headers()
-        );
+          headers: new Headers(),
+        });
       });
 
       it("throws a LangflowError if the response is not ok", async () => {
@@ -321,16 +321,16 @@ describe("LangflowClient", () => {
         });
 
         try {
-          await client.request(
-            "/run/flow-id",
-            "POST",
-            JSON.stringify({
+          await client.request({
+            path: "/run/flow-id",
+            method: "POST",
+            body: JSON.stringify({
               input_type: "chat",
               output_type: "chat",
               input_value: "Hello, world!",
             }),
-            new Headers()
-          );
+            headers: new Headers(),
+          });
           assert.fail("Expected an error to be thrown");
         } catch (error) {
           assert.ok(error instanceof LangflowError);

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface FlowRequestOptions {
   input_value: string;
   tweaks?: Tweaks;
   session_id?: string;
+  signal?: AbortSignal;
 }
 
 export type Tweak = Record<string, string | number | null | boolean>;


### PR DESCRIPTION
This pull request introduces the ability to abort requests using the `AbortController` and includes various updates to the codebase to support this feature. The changes span across multiple files, including updates to the documentation, the main code, and the test cases.

### Aborting Requests Feature:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R162-R176): Added documentation on how to use the `AbortController` to cancel requests by passing a `signal` to the `run` or `uploadFile` functions.
* [`src/flow.ts`](diffhunk://#diff-6fb359fb9ddfdacc920c12e3b6b721e58a63579872f18a1f9b6ad90575ff102cL53-R58): Updated the `Flow` class to accept an optional `signal` parameter in the `run` and `uploadFile` methods, enabling request cancellation. [[1]](diffhunk://#diff-6fb359fb9ddfdacc920c12e3b6b721e58a63579872f18a1f9b6ad90575ff102cL53-R58) [[2]](diffhunk://#diff-6fb359fb9ddfdacc920c12e3b6b721e58a63579872f18a1f9b6ad90575ff102cL65-R83) [[3]](diffhunk://#diff-6fb359fb9ddfdacc920c12e3b6b721e58a63579872f18a1f9b6ad90575ff102cL86-R99)
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L82-R94): Modified the `LangflowClient` class to handle the `signal` parameter in the `request` method, ensuring that requests can be aborted. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L82-R94) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L104-R126)
* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR36): Added the `signal` property to the `FlowRequestOptions` interface to support the aborting functionality.

### Test Updates:

* [`src/test/index.test.ts`](diffhunk://#diff-37df39de29d3c258566713382a5e31c65dcfefd9c8274b1ab7dee5247c98f65dL97-R106): Updated existing tests and added new tests to cover the aborting requests feature, ensuring that the `AbortController` works correctly and that appropriate errors are thrown when requests are aborted. [[1]](diffhunk://#diff-37df39de29d3c258566713382a5e31c65dcfefd9c8274b1ab7dee5247c98f65dL97-R106) [[2]](diffhunk://#diff-37df39de29d3c258566713382a5e31c65dcfefd9c8274b1ab7dee5247c98f65dL125-R134) [[3]](diffhunk://#diff-37df39de29d3c258566713382a5e31c65dcfefd9c8274b1ab7dee5247c98f65dL157-R166) [[4]](diffhunk://#diff-37df39de29d3c258566713382a5e31c65dcfefd9c8274b1ab7dee5247c98f65dL185-R194) [[5]](diffhunk://#diff-37df39de29d3c258566713382a5e31c65dcfefd9c8274b1ab7dee5247c98f65dL217-R267) [[6]](diffhunk://#diff-37df39de29d3c258566713382a5e31c65dcfefd9c8274b1ab7dee5247c98f65dL271-R315) [[7]](diffhunk://#diff-37df39de29d3c258566713382a5e31c65dcfefd9c8274b1ab7dee5247c98f65dL298-R342) [[8]](diffhunk://#diff-37df39de29d3c258566713382a5e31c65dcfefd9c8274b1ab7dee5247c98f65dL324-R368)