### PR TITLE
Improve typings for message stream events

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,7 @@ type TokenStreamEvent = {
 
 type AddMessageStreamEvent = {
   event: "add_message";
-  data: unknown;
+  data: MessageStreamEventData;
 };
 
 type EndStreamEvent = {
@@ -93,6 +93,41 @@ type EndStreamEvent = {
     };
   };
 };
+
+export interface MessageStreamEventData {
+  timestamp: string;
+  sender: string;
+  sender_name: string;
+  session_id: string;
+  text: string;
+  files: unknown[];
+  error: boolean;
+  edit: boolean;
+  properties: MessageStreamEventDataProperties;
+  category: string;
+  content_blocks: unknown[];
+  id: string;
+  flow_id: string;
+  duration: unknown;
+}
+
+export interface MessageStreamEventDataProperties {
+  text_color: string;
+  background_color: string;
+  edited: boolean;
+  source: MessageStreamEventDataSource;
+  icon: string;
+  allow_markdown: boolean;
+  positive_feedback: unknown;
+  state: string;
+  targets: unknown[];
+}
+
+export interface MessageStreamEventDataSource {
+  id: unknown;
+  display_name: unknown;
+  source: unknown;
+}
 
 export type StreamEvent =
   | TokenStreamEvent


### PR DESCRIPTION
This PR adds the `MessageStreamEventData` interface and updates the `AddMessageStreamEvent` type to use this interface instead of `unknown`.
This improves TypeScript typing for message stream events, making the code safer and easier to work with.

### Changes

* Define the new `MessageStreamEventData` interface in `types.ts`.
* Replace `unknown` with `MessageStreamEventData` in the `AddMessageStreamEvent` type.

### Motivation

Enhances type safety and developer experience by providing proper typings for streamed messages.

### Checklist

All steps from the contributing guide have been completed:

* [x] Dependencies installed (`npm install`)
* [x] Tests run (`npm test`)
* [x] Code transpiled (`npm run build`)
* [x] Linting passed (`npm run lint`)
* [x] Formatting applied and checked (`npm run format` / `npm run format:check`)